### PR TITLE
Fix clone URL for PyCon Ireland

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Clone the repository to a directory of your choosing:
 
 - HTTPS:
 ```
-git clone https://github.com/codebrain001/pycon-2024.git
+git clone https://github.com/codebrain001/pycon-ireland-2024.git
 ```
 
 - SSH:
 ```
-git clone git@github.com:codebrain001/pycon-2024.git
+git clone git@github.com:codebrain001/pycon-ireland-2024.git
 ```
 
 - GitHub CLI:


### PR DESCRIPTION
As pointed out during the workshop, the clone URL is wrong. This PR fixes it